### PR TITLE
Fix compiler warning about pipe

### DIFF
--- a/lib/anaphora.ex
+++ b/lib/anaphora.ex
@@ -235,7 +235,7 @@ defmodule Anaphora do
 
   defp generate_z_combinator_ys({:->, _c, [arguments, _body]}) do
     1..number_of_afn_arguments(arguments)
-      |> Enum.map &(Macro.var(String.to_atom("y#{&1}"), __MODULE__))
+      |> Enum.map(&(Macro.var(String.to_atom("y#{&1}"), __MODULE__)))
   end
 
   defp number_of_afn_arguments([{:when, _c, arguments}]), do: Enum.count(arguments) - 1


### PR DESCRIPTION
Hi, here is a fix to remove compile warning:

```
lib/anaphora.ex:238: warning: you are piping into a function call without parentheses, which may be ambiguous. Please wrap the function you are piping into in parentheses. For example:

    foo 1 |> bar 2 |> baz 3

Should be written as:

    foo(1) |> bar(2) |> baz(3)
```
